### PR TITLE
ADD: Add CMake rule to install hippomocks.h to include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.0)
 enable_testing()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long -std=c++11")
+if (NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long -std=c++11")
+endif()
 
 add_subdirectory(HippoMocksTest)
 
+install(FILES ${PROJECT_SOURCE_DIR}/HippoMocks/hippomocks.h
+        DESTINATION include/)


### PR DESCRIPTION
Add CMake rule to install header to include directory (using cmake --target install)

Useful to install hippomocks via CMake ExternalProject_Add

Hope it helps
