### PR TITLE
Fixing 64-bit IAT corruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 *.tmp
 *.user
 
+*.obj
+*.pdb
+
+Debug/
+Release/
+
 debian/*.debhelper.log
 debian/files
 debian/hippomocks*/*

--- a/HippoMocksTest/DllApi.cpp
+++ b/HippoMocksTest/DllApi.cpp
@@ -1,0 +1,36 @@
+#include "DllApi.h"
+
+int DllSum(int param)
+{
+	int sum = 0;
+
+	if (param > 0)
+	{
+		for (int i = 1; i <= 1; i++)
+		{
+			sum += i;
+		}
+	}
+
+	return sum;
+}
+
+int DllSum1()
+{
+	return DllSum(1);
+}
+
+int DllSum2()
+{
+	return DllSum(2);
+}
+
+int DllSum3()
+{
+	return DllSum(3);
+}
+
+int DllSum4()
+{
+	return DllSum(4);
+}

--- a/HippoMocksTest/DllApi.h
+++ b/HippoMocksTest/DllApi.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "DllModule.h"
+
+DLL_API int DllSum1();
+DLL_API int DllSum2();
+DLL_API int DllSum3();
+DLL_API int DllSum4();

--- a/HippoMocksTest/DllModule.h
+++ b/HippoMocksTest/DllModule.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if defined(DLL_EXPORTS)
+#define DLL_API __declspec(dllexport)
+#else
+#define DLL_API __declspec(dllimport)
+#endif

--- a/HippoMocksTest/DllModule.vcxproj
+++ b/HippoMocksTest/DllModule.vcxproj
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="DllApi.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="DllApi.h" />
+    <ClInclude Include="DllModule.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B0C20910-EF62-42C6-95B8-1C1AC804E020}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>DllModule</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;DLL_EXPORTS;_DEBUG;_WINDOWS;_USRDLL;DLLMODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;DLL_EXPORTS;_DEBUG;_WINDOWS;_USRDLL;DLLMODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;DLL_EXPORTS;NDEBUG;_WINDOWS;_USRDLL;DLLMODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;DLL_EXPORTS;NDEBUG;_WINDOWS;_USRDLL;DLLMODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/HippoMocksTest/HippoMocksTest_2012.sln
+++ b/HippoMocksTest/HippoMocksTest_2012.sln
@@ -2,6 +2,11 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HippoMocksTest", "HippoMocksTest_2012.vcxproj", "{231F5EB2-1F1D-4C41-9FC1-59118049524F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020} = {B0C20910-EF62-42C6-95B8-1C1AC804E020}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DllModule", "DllModule.vcxproj", "{B0C20910-EF62-42C6-95B8-1C1AC804E020}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,6 +24,14 @@ Global
 		{231F5EB2-1F1D-4C41-9FC1-59118049524F}.Release|Win32.Build.0 = Release|Win32
 		{231F5EB2-1F1D-4C41-9FC1-59118049524F}.Release|x64.ActiveCfg = Release|x64
 		{231F5EB2-1F1D-4C41-9FC1-59118049524F}.Release|x64.Build.0 = Release|x64
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Debug|Win32.Build.0 = Debug|Win32
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Debug|x64.ActiveCfg = Debug|x64
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Debug|x64.Build.0 = Debug|x64
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Release|Win32.ActiveCfg = Release|Win32
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Release|Win32.Build.0 = Release|Win32
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Release|x64.ActiveCfg = Release|x64
+		{B0C20910-EF62-42C6-95B8-1C1AC804E020}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HippoMocksTest/HippoMocksTest_2012.vcxproj
+++ b/HippoMocksTest/HippoMocksTest_2012.vcxproj
@@ -96,6 +96,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\DllModule.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>$(TargetDir)$(TargetFileName)</Command>
@@ -106,7 +107,7 @@
       <AdditionalOptions>/vmg %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>../hippo mocks;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../HippoMocks/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level4</WarningLevel>
@@ -117,6 +118,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\DllModule.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -135,6 +137,8 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\DllModule.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>$(TargetDir)$(TargetFileName)</Command>
@@ -145,7 +149,7 @@
       <AdditionalOptions>/vmg %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>../hippo mocks;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../HippoMocks/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level4</WarningLevel>
@@ -155,7 +159,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <TargetMachine>MachineX86</TargetMachine>
+      <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\DllModule.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -170,6 +175,7 @@
     <ClCompile Include="test_class_args.cpp" />
     <ClCompile Include="test_constref_params.cpp" />
     <ClCompile Include="test_cv_funcs.cpp" />
+    <ClCompile Include="test_dll.cpp" />
     <ClCompile Include="test_do.cpp" />
     <ClCompile Include="test_dontcare.cpp" />
     <ClCompile Include="test_except.cpp" />

--- a/HippoMocksTest/test_dll.cpp
+++ b/HippoMocksTest/test_dll.cpp
@@ -1,0 +1,20 @@
+#include "hippomocks.h"
+#include "Framework.h"
+#include "DllApi.h"
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+TEST(dllFuncCalled)
+{
+	MockRepository mocks;
+	mocks.ExpectCallFunc(DllSum1).Return(-1);
+	mocks.ExpectCallFunc(DllSum2).Return(-1);
+	mocks.ExpectCallFunc(DllSum3).Return(-1);
+	mocks.ExpectCallFunc(DllSum4).Return(-1);
+	EQUALS(DllSum1(), -1);
+	EQUALS(DllSum2(), -1);
+	EQUALS(DllSum3(), -1);
+	EQUALS(DllSum4(), -1);
+}
+
+#endif


### PR DESCRIPTION
Fixing the corrupted import address table on 64-bit dll build by
overwriting the target address memory instead of the one within jump
address table