### PR TITLE
Fix Werror on redecleration of __clear_cache

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -111,7 +111,9 @@ extern "C" __declspec(dllimport) void WINCALL DebugBreak();
 #define _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 // This clear-cache is *required*. The tests will fail if you remove it.
+#ifndef __clear_cache
 extern "C" void __clear_cache(char *beg, char *end);
+#endif
 #endif
 
 #if defined(__GNUC__) && !defined(__EXCEPTIONS)


### PR DESCRIPTION
When building for ARM targets using (at least) gcc-6.3, the build fails
with:

hippomocks.h:114:17: error: new declaration 'void __clear_cache(char*,
char*)' ambiguates built-in dec
laration 'void __clear_cache(void*, void*)' [-Werror]

This is fixed by only declaring the built-in when not already defined by
the compiler.

Signed-off-by: Martin Hundebøll <mnhu@prevas.dk>