### PR TITLE
Really fix Werror on redecleration of __clear_cache

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -111,9 +111,7 @@ extern "C" __declspec(dllimport) void WINCALL DebugBreak();
 #define _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 // This clear-cache is *required*. The tests will fail if you remove it.
-#ifndef __clear_cache
-extern "C" void __clear_cache(char *beg, char *end);
-#endif
+extern "C" void __clear_cache(void *beg, void *end);
 #endif
 
 #if defined(__GNUC__) && !defined(__EXCEPTIONS)


### PR DESCRIPTION
Commit 1a59102 ('Fix Werror on redecleration of __clear_cache') tried to
use #ifndef to fix when the built-in __clear_cache was redeclared, which
failed because #ifndef cannot be used on built-ins.

According to LLVM revision 181810[1] the gcc manual is wrong, and the
decleration should use void pointers, so update the decleration to match
the code rather than the documentation.

[1] http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20130513/079828.html

Signed-off-by: Martin Hundebøll <mnhu@prevas.dk>