### PR TITLE
Support unique ptr

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -1294,6 +1294,12 @@ std::unique_ptr<base,Deleter> MockRepository::UniqueMock(Deleter deleter) {
   return std::move(std::unique_ptr<base,Deleter>{reinterpret_cast<base *>(new unique_mock<base>(this)), deleter});
 }
 
+template<typename base, typename d>
+std::unique_ptr<base,d> tee(base*& capture, std::unique_ptr<base,d> && obj) {
+    capture = obj.get();
+    return std::move(obj);
+}
+
 
 #include "detail/defaultreporter.h"
 

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -978,6 +978,8 @@ public:
   base *Mock();
   template <typename base>
   std::unique_ptr<base> UniqueMock();
+  template <typename base, typename D>
+  std::unique_ptr<base, D> UniqueMock(D deleter);
 };
 
 // mock function providers
@@ -1285,6 +1287,11 @@ base *MockRepository::Mock() {
 template <typename base>
 std::unique_ptr<base> MockRepository::UniqueMock() {
   return std::move(std::unique_ptr<base>{reinterpret_cast<base *>(new unique_mock<base>(this))});
+}
+
+template <typename base, typename Deleter>
+std::unique_ptr<base,Deleter> MockRepository::UniqueMock(Deleter deleter) {
+  return std::move(std::unique_ptr<base,Deleter>{reinterpret_cast<base *>(new unique_mock<base>(this)), deleter});
 }
 
 

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
 	test_retval.cpp
 	test_transaction.cpp
 	test_zombie.cpp
+	test_unique_ptr.cpp
 )
 
 add_executable(HippoMocksTest64

--- a/HippoMocksTest/test_unique_ptr.cpp
+++ b/HippoMocksTest/test_unique_ptr.cpp
@@ -1,0 +1,102 @@
+#include "Framework.h"
+#include "hippomocks.h"
+#include <string>
+
+class IU {
+public:
+	virtual ~IU() { std::cout << "deleting  " << std::endl;}
+	virtual void f() = 0;// {}
+	virtual void g() {}
+	virtual int h() { return 0; }
+	virtual void i(std::string ) {}
+	virtual void j(std::string ) = 0;
+};
+
+TEST (checkUniquePtrDestruction)
+{
+    MockRepository mocks;
+    auto iu = mocks.UniqueMock<IU>();
+}
+
+TEST (checkCallsWorksOnUniquePtr)
+{
+    MockRepository mocks;
+    std::unique_ptr<IU> iu = mocks.UniqueMock<IU>();
+    mocks.ExpectCall(iu.get(), IU::f);
+    iu->f();
+}
+
+TEST (checkMissingExpectationsWorksOnUniquePtr)
+{
+    MockRepository mocks;
+    bool exceptionCaught = false;
+    std::unique_ptr<IU> iu = mocks.UniqueMock<IU>();
+    try
+    {
+        iu->f();
+    }
+    catch (HippoMocks::NotImplementedException const& e)
+    {
+        exceptionCaught = true;
+    }
+    CHECK(exceptionCaught);
+}
+
+TEST (checkNeverCallWorksOnUniquePtr)
+{
+	bool exceptionCaught = false;
+	MockRepository mocks;
+        auto iu = mocks.UniqueMock<IU>();
+	Call &callF = mocks.ExpectCall(iu.get(), IU::f);
+	mocks.OnCall(iu.get(), IU::g);
+	mocks.NeverCall(iu.get(), IU::g).After(callF);
+	iu->g();
+	iu->g();
+	iu->f();
+	try
+	{
+		iu->g();
+	}
+	catch (HippoMocks::ExpectationException &)
+	{
+		exceptionCaught = true;
+	}
+	CHECK(exceptionCaught);
+}
+
+TEST (checkClassArgumentsAcceptedWithUniquePtr)
+{
+	MockRepository mocks;
+	auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i).With("hi");
+	mocks.OnCall(iamock.get(), IU::j).With("bye");
+	iamock->i("hi");
+	iamock->j("bye");
+}
+
+TEST (checkClassArgumentsCheckedWithUniquePtr)
+{
+	MockRepository mocks;
+	auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i).With("hi");
+	mocks.OnCall(iamock.get(), IU::j).With("bye");
+	bool exceptionCaught = false;
+	try
+	{
+		iamock->i("bye");
+	}
+	catch (HippoMocks::ExpectationException)
+	{
+		exceptionCaught = true;
+	}
+	CHECK(exceptionCaught);
+	mocks.reset();
+}
+
+TEST (checkClassArgumentsIgnoredWithUniquePtr)
+{
+	MockRepository mocks;
+        auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i);
+	iamock->i("bye");
+}


### PR DESCRIPTION
This adds support for mock objects controlled by unique_ptr. In this proposal the mock repository is not the owner of the mock object - it just assists in construction. The verification of expectations thus happens when the mock object is destroyed.