### PR TITLE
Add support for nice mocks

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -1105,7 +1105,7 @@ unique_mock<T>::unique_mock(MockRepository *repository) : mock<T>(repository)
     // restore function table from mock<T>
     *(void **)this = this->funcTables[0];
     // setup destructor - since MockRepository is not the owner of the object
-    this->repo->template SetupDefaultDestructor(reinterpret_cast<T*>(this), -1);
+    this->repo->SetupDefaultDestructor(reinterpret_cast<T*>(this), -1);
 }
 
 template <typename Z>

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -1294,6 +1294,12 @@ std::unique_ptr<base,Deleter> MockRepository::UniqueMock(Deleter deleter) {
   return std::move(std::unique_ptr<base,Deleter>{reinterpret_cast<base *>(new unique_mock<base>(this)), deleter});
 }
 
+template<typename base, typename d>
+std::unique_ptr<base,d> tee(base*& capture, std::unique_ptr<base,d> && obj) {
+    capture = obj.get();
+    return std::move(obj);
+}
+
 
 #include "detail/defaultreporter.h"
 

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -978,6 +978,8 @@ public:
   base *Mock();
   template <typename base>
   std::unique_ptr<base> UniqueMock();
+  template <typename base, typename D>
+  std::unique_ptr<base, D> UniqueMock(D deleter);
 };
 
 // mock function providers
@@ -1285,6 +1287,11 @@ base *MockRepository::Mock() {
 template <typename base>
 std::unique_ptr<base> MockRepository::UniqueMock() {
   return std::move(std::unique_ptr<base>{reinterpret_cast<base *>(new unique_mock<base>(this))});
+}
+
+template <typename base, typename Deleter>
+std::unique_ptr<base,Deleter> MockRepository::UniqueMock(Deleter deleter) {
+  return std::move(std::unique_ptr<base,Deleter>{reinterpret_cast<base *>(new unique_mock<base>(this)), deleter});
 }
 
 

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
 	test_retval.cpp
 	test_transaction.cpp
 	test_zombie.cpp
+	test_unique_ptr.cpp
 )
 
 add_executable(HippoMocksTest64

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
 	test_transaction.cpp
 	test_zombie.cpp
 	test_unique_ptr.cpp
+	test_nice_mock.cpp
 )
 
 add_executable(HippoMocksTest64

--- a/HippoMocksTest/HippoMocks.dev
+++ b/HippoMocksTest/HippoMocks.dev
@@ -1,7 +1,7 @@
 [Project]
 FileName=HippoMocks.dev
 Name=HippoMocks
-UnitCount=13
+UnitCount=14
 Type=1
 Ver=1
 ObjFiles=
@@ -169,6 +169,16 @@ BuildCmd=
 
 [Unit13]
 FileName=test_unique_ptr.cpp
+CompileCpp=1
+Folder=HippoMocks
+Compile=1
+Link=1
+Priority=1000
+OverrideBuildCmd=0
+BuildCmd=
+
+[Unit14]
+FileName=test_nice_mock.cpp
 CompileCpp=1
 Folder=HippoMocks
 Compile=1

--- a/HippoMocksTest/HippoMocks.dev
+++ b/HippoMocksTest/HippoMocks.dev
@@ -1,7 +1,7 @@
 [Project]
 FileName=HippoMocks.dev
 Name=HippoMocks
-UnitCount=12
+UnitCount=13
 Type=1
 Ver=1
 ObjFiles=
@@ -159,6 +159,16 @@ BuildCmd=
 
 [Unit12]
 FileName=hippomocks.h
+CompileCpp=1
+Folder=HippoMocks
+Compile=1
+Link=1
+Priority=1000
+OverrideBuildCmd=0
+BuildCmd=
+
+[Unit13]
+FileName=test_unique_ptr.cpp
 CompileCpp=1
 Folder=HippoMocks
 Compile=1

--- a/HippoMocksTest/HippoMocks.pro
+++ b/HippoMocksTest/HippoMocks.pro
@@ -43,4 +43,5 @@ SOURCES += \
   test_regression_arg_count.cpp \
   test_retval.cpp \
   test_transaction.cpp \
+  test_unique_ptr.cpp \
   test_zombie.cpp

--- a/HippoMocksTest/HippoMocks.pro
+++ b/HippoMocksTest/HippoMocks.pro
@@ -44,4 +44,5 @@ SOURCES += \
   test_retval.cpp \
   test_transaction.cpp \
   test_unique_ptr.cpp \
+  test_nice_mock.cpp \
   test_zombie.cpp

--- a/HippoMocksTest/HippoMocksTest.vcproj
+++ b/HippoMocksTest/HippoMocksTest.vcproj
@@ -440,7 +440,12 @@
 		<File
 			RelativePath=".\test_zombie.cpp"
 			>
+                </File>
+		<File
+			RelativePath=".\test_nice_mock.cpp"
+			>
 		</File>
+
 	</Files>
 	<Globals>
 	</Globals>

--- a/HippoMocksTest/HippoMocksTest.vcproj
+++ b/HippoMocksTest/HippoMocksTest.vcproj
@@ -352,6 +352,10 @@
 		<File
 			RelativePath=".\test_autoptr.cpp"
 			>
+                </File>
+		<File
+			RelativePath=".\test_unique_ptr.cpp"
+			>
 		</File>
 		<File
 			RelativePath=".\test_cfuncs.cpp"

--- a/HippoMocksTest/HippoMocksTest_2012.vcxproj
+++ b/HippoMocksTest/HippoMocksTest_2012.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="test_transaction.cpp" />
     <ClCompile Include="test_zombie.cpp" />
     <ClCompile Include="test_unique_ptr.cpp" />
+    <ClCompile Include="test_nice_mock.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Framework.h" />

--- a/HippoMocksTest/HippoMocksTest_2012.vcxproj
+++ b/HippoMocksTest/HippoMocksTest_2012.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="test_com_support_stdcall.cpp" />
     <ClCompile Include="test_transaction.cpp" />
     <ClCompile Include="test_zombie.cpp" />
+    <ClCompile Include="test_unique_ptr.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Framework.h" />

--- a/HippoMocksTest/makefile
+++ b/HippoMocksTest/makefile
@@ -4,7 +4,7 @@ WARNFLAGS = -Wall -Wextra -pedantic -Wno-long-long
 CXXOPTS = -I../HippoMocks/ $(WARNFLAGS) -g
 TARGET = $(PREFIX)test.exe 
 
-OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_dynamic_cast.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o test_unique_ptr.o Framework.o main.o)
+OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_dynamic_cast.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o test_unique_ptr.o test_nice_mock.o Framework.o main.o)
 
 all: $(TARGETS)
 

--- a/HippoMocksTest/makefile
+++ b/HippoMocksTest/makefile
@@ -4,7 +4,7 @@ WARNFLAGS = -Wall -Wextra -pedantic -Wno-long-long
 CXXOPTS = -I../HippoMocks/ $(WARNFLAGS) -g
 TARGET = $(PREFIX)test.exe 
 
-OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_dynamic_cast.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o Framework.o main.o)
+OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_dynamic_cast.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o test_unique_ptr.o Framework.o main.o)
 
 all: $(TARGETS)
 

--- a/HippoMocksTest/test_nice_mock.cpp
+++ b/HippoMocksTest/test_nice_mock.cpp
@@ -1,0 +1,47 @@
+#include "Framework.h"
+#include "hippomocks.h"
+#include <string>
+
+class INice {
+public:
+    virtual ~INice() {}
+    virtual void a() = 0;
+    virtual void b() = 0;
+    virtual void c() = 0;
+};
+
+
+TEST (checkThatUnexpectedCallsDoNotFail)
+{
+    MockRepository mocks;
+    auto nice = mocks.NiceMock<INice>();
+    nice->a();
+    nice->b();
+    nice->c();
+}
+
+TEST (checkThatUnexpectedCallsDoNotFailForUniquePtr)
+{
+    MockRepository mocks;
+    auto nice = mocks.UniqueNiceMock<INice>();
+    nice->a();
+    nice->b();
+    nice->c();
+}
+
+TEST (checkNeverCallWorksWithNiceMock)
+{
+    bool exceptionCaught = false;
+    MockRepository mocks;
+    auto nice = mocks.NiceMock<INice>();
+    mocks.NeverCall(nice, INice::a);
+    try
+    {
+        nice->a();
+    }
+    catch (HippoMocks::ExpectationException &)
+    {
+        exceptionCaught = true;
+    }
+    CHECK(exceptionCaught);
+}

--- a/HippoMocksTest/test_unique_ptr.cpp
+++ b/HippoMocksTest/test_unique_ptr.cpp
@@ -1,0 +1,102 @@
+#include "Framework.h"
+#include "hippomocks.h"
+#include <string>
+
+class IU {
+public:
+	virtual ~IU() { std::cout << "deleting  " << std::endl;}
+	virtual void f() = 0;// {}
+	virtual void g() {}
+	virtual int h() { return 0; }
+	virtual void i(std::string ) {}
+	virtual void j(std::string ) = 0;
+};
+
+TEST (checkUniquePtrDestruction)
+{
+    MockRepository mocks;
+    auto iu = mocks.UniqueMock<IU>();
+}
+
+TEST (checkCallsWorksOnUniquePtr)
+{
+    MockRepository mocks;
+    std::unique_ptr<IU> iu = mocks.UniqueMock<IU>();
+    mocks.ExpectCall(iu.get(), IU::f);
+    iu->f();
+}
+
+TEST (checkMissingExpectationsWorksOnUniquePtr)
+{
+    MockRepository mocks;
+    bool exceptionCaught = false;
+    std::unique_ptr<IU> iu = mocks.UniqueMock<IU>();
+    try
+    {
+        iu->f();
+    }
+    catch (HippoMocks::NotImplementedException const& e)
+    {
+        exceptionCaught = true;
+    }
+    CHECK(exceptionCaught);
+}
+
+TEST (checkNeverCallWorksOnUniquePtr)
+{
+	bool exceptionCaught = false;
+	MockRepository mocks;
+        auto iu = mocks.UniqueMock<IU>();
+	Call &callF = mocks.ExpectCall(iu.get(), IU::f);
+	mocks.OnCall(iu.get(), IU::g);
+	mocks.NeverCall(iu.get(), IU::g).After(callF);
+	iu->g();
+	iu->g();
+	iu->f();
+	try
+	{
+		iu->g();
+	}
+	catch (HippoMocks::ExpectationException &)
+	{
+		exceptionCaught = true;
+	}
+	CHECK(exceptionCaught);
+}
+
+TEST (checkClassArgumentsAcceptedWithUniquePtr)
+{
+	MockRepository mocks;
+	auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i).With("hi");
+	mocks.OnCall(iamock.get(), IU::j).With("bye");
+	iamock->i("hi");
+	iamock->j("bye");
+}
+
+TEST (checkClassArgumentsCheckedWithUniquePtr)
+{
+	MockRepository mocks;
+	auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i).With("hi");
+	mocks.OnCall(iamock.get(), IU::j).With("bye");
+	bool exceptionCaught = false;
+	try
+	{
+		iamock->i("bye");
+	}
+	catch (HippoMocks::ExpectationException)
+	{
+		exceptionCaught = true;
+	}
+	CHECK(exceptionCaught);
+	mocks.reset();
+}
+
+TEST (checkClassArgumentsIgnoredWithUniquePtr)
+{
+	MockRepository mocks;
+        auto iamock = mocks.UniqueMock<IU>();
+	mocks.OnCall(iamock.get(), IU::i);
+	iamock->i("bye");
+}

--- a/HippoMocksTest/test_unique_ptr.cpp
+++ b/HippoMocksTest/test_unique_ptr.cpp
@@ -4,8 +4,8 @@
 
 class IU {
 public:
-	virtual ~IU() { std::cout << "deleting  " << std::endl;}
-	virtual void f() = 0;// {}
+	virtual ~IU() {}
+	virtual void f() = 0;
 	virtual void g() {}
 	virtual int h() { return 0; }
 	virtual void i(std::string ) {}
@@ -35,7 +35,7 @@ TEST (checkMissingExpectationsWorksOnUniquePtr)
     {
         iu->f();
     }
-    catch (HippoMocks::NotImplementedException const& e)
+    catch (HippoMocks::NotImplementedException const&)
     {
         exceptionCaught = true;
     }


### PR DESCRIPTION
Nice mocks do not complain when a method is called that is not expected. This is similar to the nice mock concept in GMock. To make use of that feature, just use `NiceMock<Type>()` instead of `Mock<Type>()`. 