### PR TITLE
FIX: restore backups in reverse order

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -4092,7 +4092,7 @@ public:
 	if (staticFuncMap.find(func) == staticFuncMap.end())
 	{
 	  staticFuncMap[func] = X;
-	  staticReplaces.push_back(new Replace(func, fp));
+	  staticReplaces.push_front(new Replace(func, fp));
 	}
 	return staticFuncMap[func];
   }

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(${PROJECT_NAME}
 	Framework.cpp
 	is_virtual.cpp
 	main.cpp
+	target_cfuncs.c
 	test_args.cpp
 	test_array.cpp
 	test_autoptr.cpp
@@ -34,8 +35,8 @@ add_executable(${PROJECT_NAME}
 	test_transaction.cpp
 	test_zombie.cpp
 )
-target_link_libraries(${PROJECT_NAME} 
-	PRIVATE 
+target_link_libraries(${PROJECT_NAME}
+	PRIVATE
 		HippoMocks
 )
 add_test(test ${PROJECT_NAME})

--- a/HippoMocksTest/makefile
+++ b/HippoMocksTest/makefile
@@ -2,9 +2,9 @@ CXX?=g++
 STDVER?=c++98
 WARNFLAGS = -Wall -Wextra -pedantic -Wno-long-long
 CXXOPTS = -I../HippoMocks/ $(WARNFLAGS) -g
-TARGET = $(PREFIX)test.exe 
+TARGET = $(PREFIX)test.exe
 
-OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o Framework.o main.o)
+OBJECTS = $(patsubst %,$(PREFIX)%,is_virtual.o test.o test_args.o test_array.o test_autoptr.o target_cfuncs.o test_cfuncs.o test_class_args.o test_constref_params.o test_cv_funcs.o test_do.o test_dontcare.o test_except.o test_exception_quality.o test_filter.o test_inparam.o test_membermock.o test_mi.o test_nevercall.o test_optional.o test_outparam.o test_overload.o test_ref_args.o test_regression_arg_count.o test_retval.o test_transaction.o test_zombie.o Framework.o main.o)
 
 all: $(TARGETS)
 
@@ -15,6 +15,9 @@ runtest: $(TARGET)
 	./$(TARGET)
 
 %.o: %.cpp makefile
+	$(CXX) $(CFLAGS) $(CXXOPTS) -std=$(STDVER) -c -o $@ $< -MMD -MP
+
+%.o: %.c makefile
 	$(CXX) $(CFLAGS) $(CXXOPTS) -std=$(STDVER) -c -o $@ $< -MMD -MP
 
 $(TARGET): $(OBJECTS)

--- a/HippoMocksTest/target_cfuncs.c
+++ b/HippoMocksTest/target_cfuncs.c
@@ -1,0 +1,16 @@
+#include "target_cfuncs.h"
+
+#ifdef _MSC_VER
+#pragma optimize( "fsa", on)
+#endif
+
+int ret_1(void)
+{
+    return 1;
+}
+
+int ret_2(void)
+{
+    return 2;
+}
+

--- a/HippoMocksTest/target_cfuncs.h
+++ b/HippoMocksTest/target_cfuncs.h
@@ -1,0 +1,17 @@
+#ifndef TARGET_CFUNCS_h
+#define TARGET_CFUNCS_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ret_1(void);
+int ret_2(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif
+

--- a/HippoMocksTest/test_cfuncs.cpp
+++ b/HippoMocksTest/test_cfuncs.cpp
@@ -1,30 +1,53 @@
 #include "hippomocks.h"
 #include "Framework.h"
+#include "target_cfuncs.h"
 
 // If it's not supported, then don't test it.
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
-int a()
-{
-  return 1;
-}
 
 TEST (checkFunctionReplacedAndChecked)
 {
-	EQUALS(a(), 1);
+	EQUALS(ret_2(), 2);
 	MockRepository mocks;
-	mocks.ExpectCallFunc(a).Return(2);
-	EQUALS(a(), 2);
+	mocks.ExpectCallFunc(ret_2).Return(7);
+	EQUALS(ret_2(), 7);
 }
 
 TEST (checkFunctionReturnedToOriginal)
 {
 	{
-		EQUALS(a(), 1);
+		EQUALS(ret_1(), 1);
 		MockRepository mocks;
-		mocks.ExpectCallFunc(a).Return(2);
-		EQUALS(a(), 2);
+		mocks.ExpectCallFunc(ret_1).Return(5);
+		EQUALS(ret_1(), 5);
 	}
-	EQUALS(a(), 1);
+	EQUALS(ret_1(), 1);
+}
+
+TEST (checkOrderFunctionReturnedToOriginal)
+{
+	{
+        EQUALS(ret_1(), 1);
+        EQUALS(ret_2(), 2);
+		MockRepository mocks;
+		mocks.ExpectCallFunc(ret_2).Return(7);
+		mocks.ExpectCallFunc(ret_1).Return(5);
+		EQUALS(ret_2(), 7);
+		EQUALS(ret_1(), 5);
+	}
+    EQUALS(ret_1(), 1);
+    EQUALS(ret_2(), 2);
+
+    /* In reversed order */
+    {
+        MockRepository mocks;
+        mocks.ExpectCallFunc(ret_1).Return(5);
+        mocks.ExpectCallFunc(ret_2).Return(7);
+        EQUALS(ret_1(), 5);
+        EQUALS(ret_2(), 7);
+    }
+    EQUALS(ret_1(), 1);
+    EQUALS(ret_2(), 2);;
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Issue:
If the tested function is less than 16 bytes and is not aligned.
And nearby function (the beginning of the next function is located with the following address) is tests:
In the backup will be copied replaced instruction and will be incorrectly restored.
Next native call of the function will cause "segmentation fault".