### PR TITLE
FIX: Hippomock does not work properly with g++ (MinGW) on Windows

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -46,12 +46,10 @@
 #define HM_NS HippoMocks::
 #endif
 
-#ifdef _MSC_VER
 #ifdef _WIN64
 #define WINCALL
 #else
 #define WINCALL __stdcall
-#endif
 #endif
 #ifndef DEBUGBREAK
 #ifdef _MSC_VER


### PR DESCRIPTION
We had to add _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
in our test. Unfortunately compilation didn't work because WINCALL was not defined on win64, mingw(g++). Our approach is to allow to not to restrict defining WINCALL only in MSVC on win64
