### PR TITLE
Add package config file generation for find_package

### DIFF
--- a/CMake/HippoMocksConfig.cmake.in
+++ b/CMake/HippoMocksConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET HippoMocks::HippoMocks)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+    include(${CMAKE_CURRENT_LIST_DIR}/HippoMocksTargets.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,38 @@
 cmake_minimum_required(VERSION 3.0)
 enable_testing()
 
-if (NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long -std=c++11")
-endif()
-add_subdirectory(HippoMocks)
-add_subdirectory(HippoMocksTest)
+project(HippoMocks)
 
-install(FILES ${PROJECT_SOURCE_DIR}/HippoMocks/hippomocks.h
-        DESTINATION include/)
+include(CTest)
+
+add_subdirectory(HippoMocks)
+if (BUILD_TESTING)
+  add_subdirectory(HippoMocksTest)
+endif()
+
+include(CMakePackageConfigHelpers)
+
+set(HIPPOMOCKS_CMAKE_CONFIG_DESTINATION "cmake/")
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/CMake/HippoMocksConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/HippoMocksConfig.cmake
+  INSTALL_DESTINATION
+    ${HIPPOMOCKS_CMAKE_CONFIG_DESTINATION}
+)
+
+install(
+  EXPORT
+    HippoMocksTargets
+  NAMESPACE
+    HippoMocks::
+  DESTINATION
+    ${HIPPOMOCKS_CMAKE_CONFIG_DESTINATION}
+)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/HippoMocksConfig.cmake"
+  DESTINATION
+    ${HIPPOMOCKS_CMAKE_CONFIG_DESTINATION}
+)

--- a/HippoMocks/CMakeLists.txt
+++ b/HippoMocks/CMakeLists.txt
@@ -1,5 +1,15 @@
-project(HippoMocks)
-
 add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE .)
+target_include_directories(HippoMocks INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_compile_features(HippoMocks INTERFACE cxx_std_11)
 
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/hippomocks.h
+        DESTINATION include/)
+
+install(
+  TARGETS
+    HippoMocks
+  EXPORT
+    HippoMocksTargets
+  DESTINATION
+    ./
+)

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.0)
 
 project(HippoMocksTests CXX)
 
+if (NOT WIN32)
+  target_compile_options(HippoMocksTests
+    PRIVATE
+      -Wall -Wextra -pedantic -Wno-long-long
+  )
+endif()
+
 add_executable(${PROJECT_NAME}
 	Framework.cpp
 	is_virtual.cpp


### PR DESCRIPTION
- no package config version file
- moved compile options to test project
- added opportunity to skip tests