### PR TITLE
Adapt to c++ change P1423R2 if detected.

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -133,6 +133,11 @@ class X{};
 #include <algorithm>
 #include <limits>
 
+#if __cplusplus > 201703L
+#include <locale>
+#include <codecvt>
+#endif
+
 #ifdef _MSC_VER
 // these warnings are pointless and huge, and will confuse new users.
 #pragma warning(push)
@@ -479,6 +484,21 @@ struct printArg
 		os << arg;
 	}
 };
+
+#if __cplusplus > 201703L
+template <>
+struct printArg<const wchar_t*>
+{
+	static inline void print(std::ostream &os, const wchar_t* arg, bool withComma)
+	{
+		if (withComma)
+			os << ",";
+
+		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> c;
+		os << c.to_bytes(arg);
+	}
+};
+#endif
 
 template <>
 struct printArg<NullType>


### PR DESCRIPTION
When compiling hippomocks with gcc 10 with the c++ standard set to c++20, the following compile error occurs:

`hippomocks.h:479:6: error: use of deleted function ‘std::basic_ostream<char, _Traits>& std::operator<<(std::basic_ostream<char, _Traits>&, const wchar_t*) [with _Traits = std::char_traits<char>]’`

This is due to P1423R2 removing the `basic_ostream<char>::operator<<` overloads for `wchar_t*` due to its unexpected behavior.

See [https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html#option7].
